### PR TITLE
make it work with symfony 3

### DIFF
--- a/DependencyInjection/EzAmpExtension.php
+++ b/DependencyInjection/EzAmpExtension.php
@@ -25,7 +25,7 @@ class EzAmpExtension extends Extension implements PrependExtensionInterface
 
     public function prepend(ContainerBuilder $container)
     {
-        $config = Yaml::parse( __DIR__ . '/../Resources/config/ezplatform.yml' );
+        $config = Yaml::parse( file_get_contents(__DIR__ . '/../Resources/config/ezplatform.yml') );
         $container->prependExtensionConfig( 'ezpublish', $config );
     }
 


### PR DESCRIPTION
It looks new symfony versions needs file_get_contents to get the contents of the file to parse. if this is not done, you receive a error saying that `config`param passed to `prependExtensionConfig` must be an array but you're passing a string instead. 

tested with ezplatform v2.0.0-beta2 